### PR TITLE
Limedrive Updates

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -37,7 +37,7 @@ public class RobotContainer {
     private final Intake intake = new Intake(INTAKE_DRIVER_ID, INTAKE_ROTATOR_ID, INTAKE_LIMIT_ID);
     private final Shooter shooter = new Shooter(SHOOTER_RIGHT_ID, SHOOTER_LEFT_ID);
     private final Blinkin blinkin = new Blinkin();
-    private final Limelight shooterLimelight = new Limelight("limelight-pbshoot");
+    private final Limelight shooterLimelight = new Limelight("limelight-pbshoot", true);
     
     private final AutonContainer auton = new AutonContainer();
     private final SendableChooser<Command> autonChooser = new SendableChooser<Command>();    

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -5,8 +5,13 @@ import static frc.robot.Constants.ControllerPorts.*;
 import static frc.robot.Constants.IntakeIDs.*;
 import static frc.robot.Constants.IntakeConstants.IntakePosition;
 import static frc.robot.Constants.ShooterIDs.*;
-
-// Command imports
+// Import subsytems
+import frc.robot.subsystems.drivetrain.SwerveDrivetrain;
+import frc.robot.subsystems.Shooter;
+import frc.robot.subsystems.Intake;
+import frc.robot.subsystems.Limelight;
+import frc.robot.subsystems.Blinkin;
+// Import commands
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.InstantCommand;
 import edu.wpi.first.wpilibj2.command.button.Trigger;
@@ -18,16 +23,11 @@ import frc.robot.commands.LimeDrive;
 import frc.robot.commands.intake_commands.IntakeAutoPickup;
 import frc.robot.commands.intake_commands.SetIntakePosition;
 import frc.robot.commands.SwerveDriveCommand;
-import frc.robot.subsystems.Intake;
-import frc.robot.subsystems.Limelight;
-import frc.robot.subsystems.Shooter;
-import frc.robot.subsystems.Blinkin;
-import frc.robot.subsystems.drivetrain.SwerveDrivetrain;
-
 // Other imports
 import edu.wpi.first.wpilibj.XboxController;
 import edu.wpi.first.wpilibj.smartdashboard.SendableChooser;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
+import edu.wpi.first.math.geometry.Translation2d;
 
 public class RobotContainer {
     private final XboxController driverController = new XboxController(DRIVER_PORT);
@@ -90,7 +90,7 @@ public class RobotContainer {
         toggleOrientationBtn.onTrue(new InstantCommand(() -> drivetrain.toggleFieldCentric()));
         // HOLD RT -> The robot will automatically drive 2 meters infront of the nearest in-view apriltag
         Trigger limeDriveBtn = new Trigger(() -> driverController.getRightTriggerAxis() > .5);
-        limeDriveBtn.whileTrue(new LimeDrive(drivetrain, shooterLimelight, -2, false));
+        limeDriveBtn.whileTrue(new LimeDrive(drivetrain, shooterLimelight, new Translation2d(0, -2), false));
     }
 
     /** Configures a set of control bindings for the robot's operator */

--- a/src/main/java/frc/robot/commands/LimeDrive.java
+++ b/src/main/java/frc/robot/commands/LimeDrive.java
@@ -96,13 +96,19 @@ public class LimeDrive extends Command {
         double xDeadbanded = MathUtil.applyDeadband(xRawOutput, .05);
         double xSlewed = slewX.calculate(xDeadbanded);
         
-        double yRawOutput = -driveControllerY.calculate(targetDist, goalDistance);
+        double yRawOutput = driveControllerY.calculate(targetDist, goalDistance);
         double yDeadbanded = MathUtil.applyDeadband(yRawOutput, .05);
         double ySlewed = slewY.calculate(yDeadbanded);
         
-        double rotRawOutput = -headingController.calculate(targetAngle, 0);
+        double rotRawOutput = headingController.calculate(targetAngle, 0);
         double rotDeadbanded = MathUtil.applyDeadband(rotRawOutput, .05);
         double rotSlewed = slewRotation.calculate(rotDeadbanded);
+               
+        // Invert the Y axis movement and rotation if limelight is rear mounted
+        if (limelight.isRearMounted()) {
+            ySlewed = -ySlewed;
+            rotSlewed = -rotSlewed;
+        }
         
         // Send the instructions to the drivetrain
         drivetrain.sendDrive(xSlewed, ySlewed, rotSlewed, true); 

--- a/src/main/java/frc/robot/subsystems/Limelight.java
+++ b/src/main/java/frc/robot/subsystems/Limelight.java
@@ -11,13 +11,6 @@ public class Limelight extends SubsystemBase {
     /** Constructs a limelight
      *  @param tableName The name of the network table that the limelight is posting to.
      *  This should be the limelight's configured hostname. Default is "limelight"
-     */
-    public Limelight(String tableName) {
-        table = NetworkTableInstance.getDefault().getTable(tableName);
-    }
-    /** Constructs a limelight
-     *  @param tableName The name of the network table that the limelight is posting to.
-     *  This should be the limelight's configured hostname. Default is "limelight"
      *  @param rearMounted Whether the limelight is mounted on the rear of the robot
      */
     public Limelight(String tableName, boolean rearMounted) {

--- a/src/main/java/frc/robot/subsystems/Limelight.java
+++ b/src/main/java/frc/robot/subsystems/Limelight.java
@@ -6,6 +6,7 @@ import edu.wpi.first.wpilibj2.command.SubsystemBase;
 
 public class Limelight extends SubsystemBase {
     private NetworkTable table;
+    private boolean rear;
 
     /** Constructs a limelight
      *  @param tableName The name of the network table that the limelight is posting to.
@@ -13,6 +14,15 @@ public class Limelight extends SubsystemBase {
      */
     public Limelight(String tableName) {
         table = NetworkTableInstance.getDefault().getTable(tableName);
+    }
+    /** Constructs a limelight
+     *  @param tableName The name of the network table that the limelight is posting to.
+     *  This should be the limelight's configured hostname. Default is "limelight"
+     *  @param rearMounted Whether the limelight is mounted on the rear of the robot
+     */
+    public Limelight(String tableName, boolean rearMounted) {
+        table = NetworkTableInstance.getDefault().getTable(tableName);
+        rear = rearMounted;
     }
 
     /** @return Whether the limelight sees at least one valid target */
@@ -25,6 +35,8 @@ public class Limelight extends SubsystemBase {
     public double getTargetArea() { return table.getEntry("ta").getDouble(0); }
     /** @return The ID of the primary apriltag in view of the limelight */
     public double getTargetID() { return table.getEntry("tid").getDouble(0); }
+    /** @return Whether the limelight is mounted on the rear of the robot */
+    public boolean isRearMounted() { return rear; }
 
     /** @return the position and rotation of the robot relative to the center of the field. 
      * This is returned as an array: [X,Y,Z,Roll,Pitch,Yaw,Latency] */


### PR DESCRIPTION
- LimeDrive constructor now requires a Translation2d instead of a distance. This allows for horizontal offset from the target.
- Limelight constructor now requires a boolean rearMounted param
- Added support for front-mounted limelights to LimeDrive
- Removed output clamping from LimeDrive because it was redundant
- Added slewing to limedrive to prevent overly aggressive acceleration
- Added support for front-mounted limelights to limedrive